### PR TITLE
Fix exec call with escaping whitespace and windows format in files path  

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-plugin-biome",
-  "version": "1.0.8",
+  "version": "1.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-plugin-biome",
-      "version": "1.0.8",
+      "version": "1.0.10",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.10.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-biome",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Biome plugin for Vite",
   "main": "dist/index.mjs",
   "module": "dist/index.mjs",

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,9 +5,9 @@ import { Options } from './types';
 
 const biomePlugin = (options: Options = { mode: 'lint', files: '.', applyFixes: false, failOnError: false }): Plugin => {
   const executeCommand = async () => {
-    const filesPath = path.join(process.cwd(), options.files ?? ".");
+    const filesPath = path.join(process.cwd(), options.files ?? ".").replace(/(\\\s+)/g, '\\\\$1');
     const commandBase = `npx @biomejs/biome`;
-    const command = `${commandBase} ${options.mode} ${filesPath} ${options.applyFixes ? (options.mode === 'format' ? '--write' : '--apply') : ''
+    const command = `${commandBase} ${options.mode} "${filesPath}" ${options.applyFixes ? (options.mode === 'format' ? '--write' : '--apply') : ''
       } --colors=force`;
 
     return new Promise<void>((resolve, reject) => {


### PR DESCRIPTION
fixes #6. 

Tested on:
- windows 11 (git bash, cmd, powershell)
- linux (ubuntu / bash)
- mac (zsh)