### PR TITLE
feat: Add more options to biome plugin

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,9 +1,34 @@
 export interface Options {
   mode?: Mode;
   files?: string;
+  /**
+   * Force color of outputted logs (adds `--colors=force`).
+   * Defaults to `true`.
+   */
+  forceColor?: boolean;
+  /** Defaults to `npx @biomejs/biome` */
+  biomeCommandBase?: string;
+  /**
+   * Specify your own arguments to follow the calls to biome cli.
+   * For example, `"--changed --config-path=..."` would
+   * limit the files checked to only the ones changed compared to your base branch,
+   * and it would specify a different config file or directory to use.
+   */
+  biomeAdditionalArgs?: string;
+  /**
+   * The level of diagnostics to show. In order, from the lowest
+   * to the most important: info, warn, error. Passing `--diagnostic-level=error`
+   * will cause Biome to print only diagnostics that contain only errors.
+   * [default: info]
+   */
+  diagnosticLevel?: DiagnosticLevel,
+  /** How the log should look like. [default: pretty] */
+  logKind?: LogKind,
   failOnError?: boolean;
   applyFixes?: boolean;
   unsafe?: boolean;
 }
 
 export type Mode = 'lint' | 'format' | 'check'
+export type LogKind = "pretty" | "compact" | "check"
+export type DiagnosticLevel = "info" | "warn" | "error"


### PR DESCRIPTION
Hello, these are a few tweaks I wanted to make to expand the customizability of the vite biome plugin.
I took most of the doc comments from the CLI directly.

For reference, this is what I use in my codebase, which I point to [my patched published version](https://www.npmjs.com/package/vite-plugin-biome-patched-1) with `"vite-plugin-biome": "npm:vite-plugin-biome-patched-1@^1.0.13"`:
```ts
const lintPlugins: PluginOption[] = [
  {
    // default settings on build (i.e. fail on error)
    ...biome({
      mode: "lint",
      failOnError: true,
      logKind: "compact",
      diagnosticLevel: "warn",
      biomeCommandBase: "bun run biome",
    }),
    apply: "build",
  },
  {
    // do not fail on serve (i.e. local development)
    ...biome({
      mode: "lint",
      failOnError: false,
      logKind: "compact",
      diagnosticLevel: "warn",
      biomeCommandBase: "bun run biome",
    }),
    apply: "serve",
    enforce: "post",
  },
];
```