### PR TITLE
Fix Windows compatibility by invoking Biome CLI with Node.js

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,8 @@ const biomePlugin = (options: Options = {}): Plugin => {
   let running: Promise<void> | null = null;
 
   const runBiome = async () => {
-    const biomeCommandBase = options.biomeCommandBase ?? `"${resolveBiomeBin()}"`;
+    // Use process.execPath to invoke Node.js explicitly (Windows doesn't support shebangs)
+    const biomeCommandBase = options.biomeCommandBase ?? `"${process.execPath}" "${resolveBiomeBin()}"`;
     const filesPath = path.join(process.cwd(), options.files ?? ".").replace(/(\\\s+)/g, '\\\\$1');
     const command = [
       biomeCommandBase,


### PR DESCRIPTION
Windows doesn't support shebangs, so the Biome CLI script must be executed explicitly with Node.js using process.execPath. This ensures cross-platform compatibility.

#16 